### PR TITLE
add support for schema prefixes

### DIFF
--- a/src/nl/pojoquery/DB.java
+++ b/src/nl/pojoquery/DB.java
@@ -177,6 +177,11 @@ public class DB {
 		return execute(db, QueryType.INSERT, insertSql.getSql(), insertSql.getParameters(), null);
 	}
 	
+	public static <PK> PK insert(Connection connection, String schemaName, String tableName, Map<String, ? extends Object> values) {
+		SqlExpression insertSql = buildInsertOrUpdate(schemaName, tableName, values, false);
+		return execute(connection, QueryType.INSERT, insertSql.getSql(), insertSql.getParameters(), null);
+	}
+	
 	public static <PK> PK insert(Connection connection, String tableName, Map<String, ? extends Object> values) {
 		SqlExpression insertSql = buildInsertOrUpdate(null, tableName, values, false);
 		return execute(connection, QueryType.INSERT, insertSql.getSql(), insertSql.getParameters(), null);

--- a/src/nl/pojoquery/annotations/Join.java
+++ b/src/nl/pojoquery/annotations/Join.java
@@ -8,6 +8,7 @@ import nl.pojoquery.pipeline.SqlQuery.JoinType;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Join {
 	JoinType type();
+	String schemaName() default "";
 	String tableName();
 	String alias();
 	String joinCondition();

--- a/src/nl/pojoquery/annotations/Link.java
+++ b/src/nl/pojoquery/annotations/Link.java
@@ -9,6 +9,7 @@ public @interface Link {
 	public static final class DEFAULT {}
 	
 	String linktable() default NONE;
+	String linkschema() default "";
 	String fetchColumn() default NONE;
 	String foreignlinkfield() default NONE;
 	String linkfield() default NONE;

--- a/src/nl/pojoquery/annotations/Table.java
+++ b/src/nl/pojoquery/annotations/Table.java
@@ -8,4 +8,6 @@ public @interface Table {
 
 	String value();
 
+	String schema() default "";
+
 }

--- a/src/nl/pojoquery/internal/TableMapping.java
+++ b/src/nl/pojoquery/internal/TableMapping.java
@@ -4,11 +4,13 @@ import java.lang.reflect.Field;
 import java.util.List;
 
 public class TableMapping {
+	public final String schemaName;
 	public final String tableName;
 	public final Class<?> clazz; // The class on which the @Table is declared
 	public final List<Field> fields;
 
-	public TableMapping(String tableName, Class<?> clazz, List<Field> fields) {
+	public TableMapping(String schemaName, String tableName, Class<?> clazz, List<Field> fields) {
+		this.schemaName = "".equals(schemaName) ? null : schemaName;
 		this.tableName = tableName;
 		this.clazz = clazz;
 		this.fields = fields;
@@ -16,7 +18,7 @@ public class TableMapping {
 	
 	@Override
 	public String toString() {
-		return "TableMapping [clazz=" + clazz.getSimpleName() + ",tableName=" + tableName + ",fields=" + fields + "]";
+		return "TableMapping [clazz=" + clazz.getSimpleName() + ",schemaName=" + schemaName + ",tableName=" + tableName + ",fields=" + fields + "]";
 	}
 }
 

--- a/test/nl/pojoquery/TestSchemaPrefixes.java
+++ b/test/nl/pojoquery/TestSchemaPrefixes.java
@@ -1,0 +1,61 @@
+package nl.pojoquery;
+
+import nl.pojoquery.annotations.Id;
+import nl.pojoquery.annotations.JoinCondition;
+import nl.pojoquery.annotations.Table;
+import nl.pojoquery.pipeline.QueryBuilder;
+import org.junit.Test;
+
+import static nl.pojoquery.TestUtils.norm;
+import static org.junit.Assert.assertEquals;
+
+public class TestSchemaPrefixes {
+
+	@Table(value="article", schema="schema1")
+	static class Article {
+		@Id
+		public Long id;
+		public String title;
+		
+		@JoinCondition("{this}.authorName={authors}.name")
+		public Person[] authors;
+	}
+	
+	@Table(value="person", schema="schema2")
+	static class Person {
+		public String name;
+	}
+	
+	@Table(value="book", schema="schema3")
+	static class Book {
+		@Id
+		public Long id;
+		public Article[] articles;
+	}
+	
+	@Test
+	public void testAliases() {
+		assertEquals(
+				norm("SELECT " + 
+						" `article`.id AS `article.id`, " + 
+						" `article`.title AS `article.title`, " + 
+						" `authors`.name AS `authors.name` " + 
+						"FROM `schema1`.`article`" +
+						" LEFT JOIN `schema2`.`person` AS `authors` ON `article`.authorName=`article.authors`.name"),
+				norm(QueryBuilder.from(Article.class).getQuery().toStatement().getSql()));
+	}
+	
+	@Test
+	public void testAliasesWithAnExtraJoin() {
+		assertEquals(
+				norm("SELECT\n" + 
+						" `book`.id AS `book.id`,\n" + 
+						" `articles`.id AS `articles.id`,\n" + 
+						" `articles`.title AS `articles.title`,\n" + 
+						" `articles.authors`.name AS `articles.authors.name`\n" + 
+						"FROM `schema3`.`book`\n" +
+						" LEFT JOIN `schema1`.`article` AS `articles` ON `book`.id = `articles`.book_id\n" +
+						" LEFT JOIN `schema2`.`person` AS `articles.authors` ON `articles`.authorName=`articles.authors`.name"),
+				norm(QueryBuilder.from(Book.class).getQuery().toStatement().getSql()));
+	}
+}

--- a/test/nl/pojoquery/integrationtest/TestSchemaPrefixes.java
+++ b/test/nl/pojoquery/integrationtest/TestSchemaPrefixes.java
@@ -1,0 +1,110 @@
+package nl.pojoquery.integrationtest;
+
+import nl.pojoquery.DB;
+import nl.pojoquery.PojoQuery;
+import nl.pojoquery.SqlExpression;
+import nl.pojoquery.annotations.Id;
+import nl.pojoquery.annotations.Table;
+import nl.pojoquery.integrationtest.db.MysqlDatabases;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.sql.DataSource;
+import java.util.List;
+import java.util.Map;
+
+public class TestSchemaPrefixes {
+	private static String[] schemas = new String[]{
+		"pojoquery_integrationtest_schema1",
+		"pojoquery_integrationtest_schema2",
+		"pojoquery_integrationtest_schema3"
+	};
+
+	public static DataSource dropAndRecreate() {
+		String host = System.getProperty("pojoquery.integrationtest.host", "localhost");
+		String username = System.getProperty("pojoquery.integrationtest.username", "root");
+		String password = System.getProperty("pojoquery.integrationtest.password", "");
+
+		DataSource db = MysqlDatabases.getMysqlDataSource(host, null, username, password);
+
+		for (String schema : schemas) {
+			DB.executeDDL(db, "DROP DATABASE IF EXISTS " + schema);
+			DB.executeDDL(db, "CREATE DATABASE " + schema + " DEFAULT CHARSET utf8");
+		}
+
+		return db;
+	}
+
+
+	@Table(value="article", schema="pojoquery_integrationtest_schema1")
+	static class Article {
+		@Id
+		public Long id;
+		public String title;
+	}
+
+	@Table(value="book", schema="pojoquery_integrationtest_schema2")
+	static class Book {
+		@Id
+		public Long id;
+		public String title;
+		public Article[] articles;
+	}
+
+	@Test
+	public void testCrud() {
+		List<Map<String, Object>> results;
+
+		DataSource db = dropAndRecreate();
+		DB.executeDDL(db, "CREATE TABLE pojoquery_integrationtest_schema1.article(id bigint not null auto_increment, primary key(id), book_id bigint default null, title varchar(255))");
+		DB.executeDDL(db, "CREATE TABLE pojoquery_integrationtest_schema2.book(id bigint not null auto_increment, primary key(id), title varchar(255))");
+		DB.insert(
+			db,
+			"pojoquery_integrationtest_schema1",
+			"article",
+			Map.of(
+				"title", "How to awesomize stuff"
+			)
+		);
+		results = DB.queryRows(db, "SELECT title FROM pojoquery_integrationtest_schema1.article WHERE id=1");
+		Assert.assertEquals(1, results.size());
+		Assert.assertEquals("How to awesomize stuff", results.get(0).get("title"));
+		DB.insertOrUpdate(
+			db,
+			"pojoquery_integrationtest_schema1",
+			"article",
+			Map.of(
+				"id", 1,
+				"title", "How to awesomize stuff even better"
+			)
+		);
+		results = DB.queryRows(db, "SELECT title FROM pojoquery_integrationtest_schema1.article WHERE id=1");
+		Assert.assertEquals(1, results.size());
+		Assert.assertEquals("How to awesomize stuff even better", results.get(0).get("title"));
+		DB.update(
+			db,
+			"pojoquery_integrationtest_schema1",
+			"article",
+			Map.of(
+				"title", "How to awesomize stuff to the max"
+			),
+			Map.of(
+				"id", 1
+			)
+		);
+
+		results = DB.queryRows(db, "SELECT title FROM pojoquery_integrationtest_schema1.article WHERE id=1");
+		Assert.assertEquals(1, results.size());
+		Assert.assertEquals("How to awesomize stuff to the max", results.get(0).get("title"));
+
+		DB.insert(db, "pojoquery_integrationtest_schema1", "article", Map.of("id", 2, "title", "Part II - how to make sure stuff works"));
+		DB.insert(db, "pojoquery_integrationtest_schema2", "book", Map.of("id", 1, "title", "Great lessons from the beyond"));
+
+		DB.update(db, new SqlExpression("UPDATE pojoquery_integrationtest_schema1.article SET book_id=1"));
+
+		List<Book> books = PojoQuery.build(Book.class).execute(db);
+
+		Assert.assertEquals(1, books.size());
+		Assert.assertEquals(2, books.get(0).articles.length);
+	}
+}


### PR DESCRIPTION
Adds the possibility of specifying schema prefixes in `@Table` annotations and in `DB.insert`, `DB.update` and `DB.insertOrUpdate` calls.